### PR TITLE
删除WxPayApi私有构造方法,方便继承改类实现自己的接口

### DIFF
--- a/IJPay-WxPay/src/main/java/com/ijpay/wxpay/WxPayApi.java
+++ b/IJPay-WxPay/src/main/java/com/ijpay/wxpay/WxPayApi.java
@@ -262,9 +262,6 @@ public class WxPayApi {
      */
     private static final String DOWNLOAD_BILL_SANDBOX_URL = "https://api.mch.weixin.qq.com/sandboxnew/pay/downloadbill";
 
-    private WxPayApi() {
-    }
-
     /**
      * 获取验签秘钥API
      *


### PR DESCRIPTION
删除WxPayApi私有构造方法,方便继承改类实现自己的接口