### PR TITLE
增加微信支付v3版CloseOrderModel

### DIFF
--- a/IJPay-WxPay/src/main/java/com/ijpay/wxpay/model/v3/CloseOrderModel.java
+++ b/IJPay-WxPay/src/main/java/com/ijpay/wxpay/model/v3/CloseOrderModel.java
@@ -1,0 +1,24 @@
+package com.ijpay.wxpay.model.v3;
+
+import com.ijpay.core.model.BaseModel;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Accessors(chain = true)
+public class CloseOrderModel extends BaseModel {
+    private String appid;
+    private String sub_appid;
+    private String mchid;
+    private String sub_mchid;
+    private String out_trade_no;
+    private String nonce_str;
+    private String sign;
+    private String sign_type;
+
+
+}


### PR DESCRIPTION
增加微信支付v3版CloseOrderModel，解决微信支付关闭订单时报错